### PR TITLE
Support GVIZ "Configuration Options" along with transformations

### DIFF
--- a/render.js
+++ b/render.js
@@ -1807,9 +1807,10 @@ var afterquery = (function() {
           grid = fillNullsWithZero(grid);
         }
         grid = limitDecimalPrecision(grid);
-        if (args.get('title')) {
-          options.title = args.get('title');
-        }
+        
+        // Scan and add all args not for afterquery to GViz options.
+        scanGVizChartOptions(args, options);
+        
         if (charttype == 'stackedarea' || charttype == 'stacked') {
           t = new google.visualization.AreaChart(el);
           options.isStacked = true;
@@ -1919,7 +1920,47 @@ var afterquery = (function() {
     });
   }
 
+  function scanGVizChartOptions(args, options) {
+    // Parse args to be sent to GViz.
+    var allArgs = args['all'];
+    for (var i in allArgs) {
+      var key = allArgs[i][0];
+      // Ignore params sent for afterquery.
+      if (key == 'trace'
+          || key == 'url'
+          || key == 'chart'
+          || key == 'editlink'
+          || key == 'intensify'
+          || key == 'order'
+          || key == 'group'
+          || key == 'limit'
+          || key == 'filter'
+          || key == 'q'
+          || key == 'pivot'
+          || key == 'treegroup'
+          || key == 'extract_regexp') {
+        continue;
+      }
+      // Add params for GViz API into options object.
+      addGVizChartOption(options, key, allArgs[i][1]);
+    }
+    console.debug('Options sent to GViz');
+    console.debug(options);
+  }
 
+  function addGVizChartOption(options, key, value) {
+    if (key.indexOf('.') > -1) {
+      var subObjects = key.split('.');
+      if (!options[subObjects[0]]) {
+        options[subObjects[0]] = {};
+      }
+      addGVizChartOption(options[subObjects[0]],
+        key.substring(key.indexOf('.') + 1), value);
+    } else {
+      options[key] = value;
+    }
+  }
+  
   function finishQueue(queue, args, done) {
     var trace = args.get('trace');
     if (trace) {


### PR DESCRIPTION
A feature by which a user can provide configuration options along with the transformations to be transferred to the underlying gviz chart without having to explicitly list them in afterquery code. This way users have a tool to, for example, change the look of the chart, activate things such as logarithmic scales, invert the axes, etc.
