### PR TITLE
Transform rename

### DIFF
--- a/render.js
+++ b/render.js
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Additional modifications 2015 by Alan De Smet, 
+ * Center for High Throughput Computing, University of Wisconsin - Madison.
+ * Licensed under the Apache License, Version 2.0.
+ */
 'use strict';
 
 var afterquery = (function() {

--- a/render.js
+++ b/render.js
@@ -1291,6 +1291,24 @@ var afterquery = (function() {
     return grid;
   }
 
+  function doRename(ingrid, argval) {
+	console.debug('rename:', argval);
+    var parts = trySplitOne(argval, '=');
+    var src = parts[0];
+    var dst = parts[1];
+    var grid = {
+      data: ingrid.data,
+      types: ingrid.types,
+      headers: [],
+    };
+    for(var i = 0; i < ingrid.headers.length; i++) {
+      var header = ingrid.headers[i];
+      if(header === src) { header = dst; }
+      grid.headers.push(header);
+    }
+    console.debug('grid:', grid);
+    return grid;
+  };
 
   function yspread(grid) {
     for (var rowi in grid.data) {
@@ -1650,6 +1668,8 @@ var afterquery = (function() {
         transform(doExtractRegexp, argval);
       } else if (argkey == 'quantize') {
         transform(doQuantize, argval);
+      } else if (argkey == 'rename') {
+        transform(doRename, argval);
       } else if (argkey == 'yspread') {
         transform(doYSpread, argval);
       }

--- a/render.js
+++ b/render.js
@@ -1306,11 +1306,18 @@ var afterquery = (function() {
       types: ingrid.types,
       headers: [],
     };
-    for(var i = 0; i < ingrid.headers.length; i++) {
+
+	var i;
+    var done = false;
+    for(i = 0; i < ingrid.headers.length; i++) {
       var header = ingrid.headers[i];
-      if(header === src) { header = dst; }
+      if((!done) && (header === src)) {
+        header = dst;
+        done = true;
+      }
       grid.headers.push(header);
     }
+
     console.debug('grid:', grid);
     return grid;
   };


### PR DESCRIPTION
Useful if your source data has jargon heavy headers, and you want to give them more widely recognizable headers when showing the charts to someone else.
