### PR TITLE
Load and merge multiple URLs

### DIFF
--- a/render.js
+++ b/render.js
@@ -1507,12 +1507,6 @@ var afterquery = (function() {
       newrows[row] = newrow.slice(0);
     }
 
-/*
-  TODO TODO // TODO
-  TODO test mixed xhr/jsonp
-  TODO test-many.html
-  */
-
     // Copy over data where we have a header and type match.
     for(b_colnum = 0; b_colnum < b.headers.length; b_colnum++) {
       b_header =  b.headers[b_colnum];

--- a/render.js
+++ b/render.js
@@ -2360,7 +2360,7 @@ var afterquery = (function() {
       });
     } else {
       enqueue(queue, 'init data', function(_, done) {
-        done(startdata);
+        done([startdata]);
       });
     }
 

--- a/render.js
+++ b/render.js
@@ -1492,16 +1492,16 @@ var afterquery = (function() {
 
     // Stub in space for new data.
     var newrow = new Array(a.headers.length);
-	for(i = 0; i < a.headers.length; i++) {
-		switch(a.types[i]) {
-		case T_NUM: newrow[i] = NaN; break;
-		case T_DATE: newrow[i] = new Date(1970,1,1,0,0,0); break;
-		case T_DATETIME: newrow[i] = new Date(1970,1,1,0,0,0); break;
-		case T_BOOL: newrow[i] = NaN; break;
-		case T_STRING: newrow[i] = ''; break;
-		default: newrow[i] = null;
-		}
-	}
+    for(i = 0; i < a.headers.length; i++) {
+      switch(a.types[i]) {
+      case T_NUM: newrow[i] = NaN; break;
+      case T_DATE: newrow[i] = new Date(1970,1,1,0,0,0); break;
+      case T_DATETIME: newrow[i] = new Date(1970,1,1,0,0,0); break;
+      case T_BOOL: newrow[i] = NaN; break;
+      case T_STRING: newrow[i] = ''; break;
+      default: newrow[i] = null;
+      }
+    }
     var newrows = new Array(b.data.length);
     for(row = 0; row < b.data.length; row++) {
       newrows[row] = newrow.slice(0);

--- a/render.js
+++ b/render.js
@@ -1492,19 +1492,26 @@ var afterquery = (function() {
 
     // Stub in space for new data.
     var newrow = new Array(a.headers.length);
+	for(i = 0; i < a.headers.length; i++) {
+		switch(a.types[i]) {
+		case T_NUM: newrow[i] = NaN; break;
+		case T_DATE: newrow[i] = new Date(1970,1,1,0,0,0); break;
+		case T_DATETIME: newrow[i] = new Date(1970,1,1,0,0,0); break;
+		case T_BOOL: newrow[i] = NaN; break;
+		case T_STRING: newrow[i] = ''; break;
+		default: newrow[i] = null;
+		}
+	}
     var newrows = new Array(b.data.length);
     for(row = 0; row < b.data.length; row++) {
       newrows[row] = newrow.slice(0);
     }
 
-    console.log("a:       ", a);
-    console.log(" .headers", a.headers);
-    console.log(" .types  ", a.types);
-    console.log(" .data   ", a.data);
-    console.log("b:       ", b);
-    console.log(" .headers", b.headers);
-    console.log(" .types  ", b.types);
-    console.log(" .data   ", b.data);
+/*
+  TODO TODO // TODO
+  Test jsonp
+  test mixed xhr/jsonp
+  */
 
     // Copy over data where we have a header and type match.
     for(b_colnum = 0; b_colnum < b.headers.length; b_colnum++) {
@@ -1524,7 +1531,7 @@ var afterquery = (function() {
     for(i = 0; i < b_new_cols.length; i++) {
       b_colnum = b_new_cols[i];
       out.headers.push(b.headers[b_colnum]);
-      out.types.push(b.headers[b_colnum]);
+      out.types.push(b.types[b_colnum]);
       for(row = 0; row < b.data.length; row++) {
         newrows[row].push( b.data[row][b_colnum]);
       }
@@ -2299,10 +2306,6 @@ var afterquery = (function() {
 
 
   function getUrlData(state, success_func, error_func) {
-    console.log("================================================================");
-    console.log("        todo:   ", state.todo);
-    console.log("        success:", state.success);
-    console.log("        failure:", state.failure);
     if(state.todo.length === 0) {
       // All URLs attempted
       if(state.rawdata.length > 0) {

--- a/render.js
+++ b/render.js
@@ -1509,8 +1509,8 @@ var afterquery = (function() {
 
 /*
   TODO TODO // TODO
-  Test jsonp
-  test mixed xhr/jsonp
+  TODO test mixed xhr/jsonp
+  TODO test-many.html
   */
 
     // Copy over data where we have a header and type match.
@@ -2181,7 +2181,8 @@ var afterquery = (function() {
           );
         },
       error: function(jqXHR, textStatus, errorThrown) {
-       getUrlDataFailure(textStatus, errorThrown, state, success_func, error_func);
+      console.debug("XHR failed:", textStatus, errorThrown);
+      error_func(state, success_func, getUrlDataFailure);
         }
       }
     );
@@ -2189,6 +2190,8 @@ var afterquery = (function() {
 
 
   function getUrlData_jsonp(state, success_func, error_func) {
+    var url = state.todo[0];
+
     var iframe = document.createElement('iframe');
     iframe.style.display = 'none';
 

--- a/render.js
+++ b/render.js
@@ -1475,6 +1475,82 @@ var afterquery = (function() {
     return out;
   }
 
+  function mergeGrids(a, b) {
+    var b_colnum;
+    var b_header;
+    var a_colnum;
+    var row;
+    var i;
+
+    var out = {
+      headers: a.headers.slice(0),
+      types: a.types.slice(0),
+      data: a.data
+    };
+
+    var b_new_cols = [];
+
+    // Stub in space for new data.
+    var newrow = new Array(a.headers.length);
+    var newrows = new Array(b.data.length);
+    for(row = 0; row < b.data.length; row++) {
+      newrows[row] = newrow.slice(0);
+    }
+
+    console.log("a:       ", a);
+    console.log(" .headers", a.headers);
+    console.log(" .types  ", a.types);
+    console.log(" .data   ", a.data);
+    console.log("b:       ", b);
+    console.log(" .headers", b.headers);
+    console.log(" .types  ", b.types);
+    console.log(" .data   ", b.data);
+
+    // Copy over data where we have a header and type match.
+    for(b_colnum = 0; b_colnum < b.headers.length; b_colnum++) {
+      b_header =  b.headers[b_colnum];
+      a_colnum = a.headers.indexOf(b_header);
+      if(a_colnum < 0 || b.types[b_colnum] != a.types[a_colnum]) {
+        // Can't merge. Next column.
+        b_new_cols.push(b_colnum);
+        continue;
+      }
+      for(row = 0; row < b.data.length; row++) {
+        newrows[row][a_colnum] = b.data[row][b_colnum];
+      }
+    }
+
+    // Everything left is new columns
+    for(i = 0; i < b_new_cols.length; i++) {
+      b_colnum = b_new_cols[i];
+      out.headers.push(b.headers[b_colnum]);
+      out.types.push(b.headers[b_colnum]);
+      for(row = 0; row < b.data.length; row++) {
+        newrows[row].push( b.data[row][b_colnum]);
+      }
+    }
+
+
+    out.data = out.data.concat(newrows);
+    return out;
+  }
+
+  function gridFromManyData(rawdata) {
+    if(rawdata.length === 0) {
+      return {headers: [], data: [], types: []};
+    }
+
+    var grid = gridFromData(rawdata[0]);
+    var newgrid;
+    var i;
+    for(i = 1; i < rawdata.length; i++) {
+      newgrid = gridFromData(rawdata[i]);
+      grid = mergeGrids(grid,newgrid);
+    }
+    return grid;
+  }
+
+
 
   function gridFromData(rawdata) {
     if (rawdata && rawdata.headers && rawdata.data && rawdata.types) {
@@ -2085,19 +2161,27 @@ var afterquery = (function() {
   }
 
 
-  function getUrlData_xhr(url, success_func, error_func) {
+  function getUrlData_xhr(state, success_func, error_func) {
     jQuery.support.cors = true;
-    jQuery.ajax(url, {
+    jQuery.ajax(state.todo[0], {
       headers: { 'X-DataSource-Auth': 'a' },
       xhrFields: { withCredentials: true },
       dataType: 'text',
-      success: function(text) { extractJsonFromJsonp(text, success_func); },
-      error: error_func
-    });
+      success: function(text) {
+        extractJsonFromJsonp(text, function(grid) {
+          getUrlDataSuccess(grid, state, success_func, error_func);
+          }
+          );
+        },
+      error: function(jqXHR, textStatus, errorThrown) {
+       getUrlDataFailure(textStatus, errorThrown, state, success_func, error_func);
+        }
+      }
+    );
   }
 
 
-  function getUrlData_jsonp(url, success_func, error_func) {
+  function getUrlData_jsonp(state, success_func, error_func) {
     var iframe = document.createElement('iframe');
     iframe.style.display = 'none';
 
@@ -2105,7 +2189,7 @@ var afterquery = (function() {
       var successfunc_called;
       var real_success_func = function(data) {
         console.debug('calling success_func');
-        success_func(data);
+        getUrlDataSuccess(data, state, success_func, error_func);
         successfunc_called = true;
       };
 
@@ -2172,8 +2256,7 @@ var afterquery = (function() {
         if (successfunc_called) {
           console.debug('json load was successful.');
         } else {
-          err('Error loading data; check javascript console for details.');
-          err('<a href="' + encodeURI(url) + '">' + encodeURI(url) + '</a>');
+          getUrlDataFailure("Error loading data; check javascript console for details.", "", state, success_func, error_func);
         }
       };
 
@@ -2201,29 +2284,79 @@ var afterquery = (function() {
     document.body.appendChild(iframe);
   }
 
+  function getUrlDataSuccess(data, state, success_func, error_func) {
+    var url = state.todo.shift();
+    state.success.push(url);
+    state.rawdata.push(data);
+    setTimeout(function(){ getUrlData(state, success_func, error_func); }, 0);
+  }
 
-  function getUrlData(url, success_func, error_func) {
+  function getUrlDataFailure(textStatus, errorThrown, state, success_func, error_func) {
+    var url = state.todo.shift();
+    state.failure.push({url:url, status: textStatus+" "+errorThrown});
+    setTimeout(function(){ getUrlData(state, success_func, error_func); }, 0);
+  }
+
+
+  function getUrlData(state, success_func, error_func) {
+    console.log("================================================================");
+    console.log("        todo:   ", state.todo);
+    console.log("        success:", state.success);
+    console.log("        failure:", state.failure);
+    if(state.todo.length === 0) {
+      // All URLs attempted
+      if(state.rawdata.length > 0) {
+        // At least one success is considered success.
+        success_func(state.rawdata);
+      } else {
+        // Failure
+        error_func(state.failure[0].url, state.failure[0].status);
+      }
+      return;
+    }
+
+    var url = state.todo[0];
+    showstatus('Loading <a href="' + encodeURI(url) + '">data</a>...');
+
     console.debug('fetching data url:', url);
     var onError = function(xhr, msg) {
       console.debug('xhr returned error:', msg);
       console.debug('(trying jsonp instead)');
-      getUrlData_jsonp(url, success_func, error_func);
+      getUrlData_jsonp(state, success_func, error_func);
     };
-    getUrlData_xhr(url, success_func, onError);
+    getUrlData_xhr(state, success_func, onError);
   }
 
 
   function addUrlGetters(queue, args, startdata) {
+    var i;
+    var urls;
+    var url;
     if (!startdata) {
-      var url = args.get('url');
-      console.debug('original data url:', url);
-      if (!url) throw new Error('Missing url= in query parameter');
-      if (url.indexOf('//') == 0) url = window.location.protocol + url;
-      url = extendDataUrl(url);
-      showstatus('Loading <a href="' + encodeURI(url) + '">data</a>...');
+      urls = [];
+      for(i = 0; i < args.all.length; i++) {
+        var key = args.all[i][0];
+        if(key === 'url') {
+          var url = args.all[i][1];
+          if (url.indexOf('//') == 0) url = window.location.protocol + url;
+          url = extendDataUrl(url);
+          urls.push(url);
+        }
+      }
+      console.debug("Original data URLs:", urls);
+      if(urls.length === 0) {
+         throw new Error('Missing url= in query parameter');
+      }
+
+      var state = {
+        todo: urls,
+        success: [],
+        failure: [],
+        rawdata: [],
+      };
 
       enqueue(queue, 'get data', function(_, done) {
-        getUrlData(url, wrap(done), wrap(gotError, url));
+        getUrlData(state, wrap(done), wrap(gotError, urls[0]));
       });
     } else {
       enqueue(queue, 'init data', function(_, done) {
@@ -2233,7 +2366,7 @@ var afterquery = (function() {
 
     enqueue(queue, 'parse', function(rawdata, done) {
       console.debug('rawdata:', rawdata);
-      var outgrid = gridFromData(rawdata);
+      var outgrid = gridFromManyData(rawdata);
       console.debug('grid:', outgrid);
       done(outgrid);
     });


### PR DESCRIPTION
This change allows multiple url= entries. They're loaded in order and concatenated. Identically named and typed fields are merged.

This is useful if the source data is split across multiple files, say, one file per day, and we want result across multiple days.
